### PR TITLE
Error de calculo

### DIFF
--- a/_informatica/1/gohp/ejercicios-resueltos.md
+++ b/_informatica/1/gohp/ejercicios-resueltos.md
@@ -40,4 +40,4 @@ Despejando y resolviendo:
 
 Simplemente debemos aplicar la fórmula:
 
-\\( Beneficios = I_{Totales} - C_{Totales} = 0,25 \times 29.000 - (3.606 + 0,1 \times 29.000) = 6.010\ euros \\)
+\\( Beneficios = I_{Totales} - C_{Totales} = 0,25 \times 29.000 - (3.606 + 0,1 \times 29.000) = 744\ euros \\)


### PR DESCRIPTION
Hay un error de calculo en el ejercicio resuelto, el resultado de: 0,25×29.000−(3.606+0,1×29.000) es igual a 744.

https://www.google.com/search?q=0%2C25%C3%9729.000%E2%88%92(3.606%2B0%2C1%C3%9729.000)&oq=0%2C25%C3%9729.000%E2%88%92(3.606%2B0%2C1%C3%9729.000)&aqs=chrome..69i57j6.230j0j7&sourceid=chrome&ie=UTF-8